### PR TITLE
Fix LCA(i,i) = i

### DIFF
--- a/taxonomy/lca.go
+++ b/taxonomy/lca.go
@@ -67,6 +67,9 @@ func (t Taxonomy) LCA(values ...int) (*taxnode, error) {
 }
 
 func lcaHelper(E, L, H []int, M [][]int, i, j int) int {
+	if i == j {
+		return i
+	}
 	v1 := H[i-1]
 	v2 := H[j-1]
 	if v1 > v2 {


### PR DESCRIPTION
Currently, a BLAST result with entries with the same taxonomy IDs gets the parent taxonomy ID as result.

For example, the following line is for the species Papiine herpesvirus 2:
````
Q_1        gi|116260100|gb|ABJ91141.1|     100.00  56      0       0       1       56      1       56      2e-27     104
````

However, when I duplicate this line (or just have another result with the same taxID), the result is given as genus Simplexvirus:
````
Q_1        gi|116260100|gb|ABJ91141.1|     100.00  56      0       0       1       56      1       56      2e-27     104
Q_1        gi|116260100|gb|ABJ91141.1|     100.00  56      0       0       1       56      1       56      2e-27     104
````

This commit fixes that.