### PR TITLE
Dynamic programming matrix was not filled properly

### DIFF
--- a/taxonomy/taxonomy.go
+++ b/taxonomy/taxonomy.go
@@ -325,7 +325,7 @@ func New(nodesfn, namesfn, dictfn string, savemem bool) (*Taxonomy, error) {
 	fmt.Fprintf(os.Stderr, "Preprocessing RMQ ... ")
 	s1 = time.Now()
 	M := makeMatrix(maxNodes)
-	rmqPrep(&M, L[:len(L)-1], maxNodes)
+	rmqPrep(&M, L[:len(L)-1], maxNodes * 2)
 	s2 = time.Now()
 	dur = s2.Sub(s1)
 	fmt.Fprintf(os.Stderr, "Done (%.3f sec)\n", dur.Seconds())


### PR DESCRIPTION
During evaluation of the tool i found that the DP matrix for the RMQ was not filled properly, resulting in a lot of nodes with LCA root. For example maus + human results in the root node.

Thank you for the great implementation in all other regards. I have ported the code to C++ and integrated it into our homology search, clustering and metagenomics suite [MMseqs2](https://github.com/soedinglab/mmseqs2). 